### PR TITLE
Added (fixed?) support for deriving DSH, QA, TA and generating selecors for newtypes with phantom type variables

### DIFF
--- a/src/Database/DSH/Frontend/TupleTypes.hs
+++ b/src/Database/DSH/Frontend/TupleTypes.hs
@@ -553,6 +553,7 @@ mkTupElemTerm width idx arg = do
 
 -- | From a list of operand terms, construct a DSH tuple term.
 mkTupConstTerm :: [Exp] -> Q Exp
+mkTupConstTerm [t] = return t
 mkTupConstTerm ts
     | length ts <= 16 = return $ AppE (ConE $ mkName "TupleConstE")
                                $ foldl' AppE (ConE $ innerConst "" $ length ts) ts


### PR DESCRIPTION
This involved fixing some places where Template Haskell would try to generate things like TupElem1_1 (instead we just return the bare expression in the case of singletons now).

For the phantom type variables, I used reifyRoles to detect phantom type variables, which I don't include in the context for QA, TA and View.

Why?

Because if we have a database with lots of tables like:

```
data Foo = Foo
    { fooId :: Integer
    }
  deriving (Eq, Ord, Read, Show)
deriveDSH ''Foo
deriveTA ''Foo
generateTableSelectors ''Foo

data Bar = Bar
    { barId :: Integer
    , fooId :: Integer
    }
  deriving (Eq, Ord, Read, Show)
deriveDSH ''Bar
deriveTA ''Bar
generateTableSelectors ''Bar
```

where we have "id" fields which reference "id" fields in other tables, we'd like to encode that in the type system, e.g., with the following type:

```
newtype ID a = ID Integer
  deriving (Eq, Ord, Read, Show)
deriveDSH ''ID
deriveTA ''ID
```

Now we can change `Foo` and `Bar` above as follows:

```
data Foo = Foo
    { fooId :: ID Foo
    }
  deriving (Eq, Ord, Read, Show)
deriveDSH ''Foo
deriveTA ''Foo
generateTableSelectors ''Foo

data Bar = Bar
    { barId :: ID Bar
    , fooId :: ID Foo
    }
  deriving (Eq, Ord, Read, Show)
deriveDSH ''Bar
deriveTA ''Bar
generateTableSelectors ''Bar
```

And while the above would have compiled before this commit, it was not possible to compare `Q (ID Foo)` for equality, because `Foo` was not an instance of `BasicType`. But because it is a phantom type parameter, it doesn't need to be.
